### PR TITLE
JNG-3230 NPE on unset feature

### DIFF
--- a/src/main/java/hu/blackbelt/judo/operation/utils/AbstractGeneratedScript.java
+++ b/src/main/java/hu/blackbelt/judo/operation/utils/AbstractGeneratedScript.java
@@ -168,7 +168,7 @@ public abstract class AbstractGeneratedScript implements Function<Payload, Paylo
 
     protected Collection<Container> createImmutableContainerList(Collection<Container> containers) {
         List<Container> result = new ArrayList<>();
-        if (containers == null || containers.isEmpty()) return result;
+        if (containers == null) return result;
         for (Container container : containers) {
             result.add(createImmutableContainer(container));
         }
@@ -177,7 +177,7 @@ public abstract class AbstractGeneratedScript implements Function<Payload, Paylo
 
     protected Collection<Container> createMutableContainerList(Collection<Container> containers) {
         List<Container> result = new ArrayList<>();
-        if (containers == null || containers.isEmpty()) return result;
+        if (containers == null) return result;
         for (Container container : containers) {
             result.add(createMutableContainer(container));
         }
@@ -509,7 +509,7 @@ public abstract class AbstractGeneratedScript implements Function<Payload, Paylo
 
     protected Set<Container> containersFromNavigation(Collection<Container> containers, String referenceName) {
         Set<Container> result = new LinkedHashSet<>();
-        if (containers == null || containers.isEmpty()) return result;
+        if (containers == null) return result;
         for (Container container : containers) {
             result.addAll(containersFromNavigation(container, referenceName));
         }


### PR DESCRIPTION
Null safety improved in AbstractGeneratedScript by adding null checks to operations' parameters
Additional improvement (revertible if not needed): in equals method Objects#equals util function replaced with generic equals